### PR TITLE
Sets page count text to same font size/style as score count text

### DIFF
--- a/pages/GamePageChildren/HeaderChildren/PageCount.js
+++ b/pages/GamePageChildren/HeaderChildren/PageCount.js
@@ -7,7 +7,7 @@ const StyledText = styled(Text);
 export default function PageCount({ page }) {
 
     return (
-        <StyledText className="font-lexend text-sm text-white m-3 p-1 leading-6" >
+        <StyledText className="leading-6 font-lexend-bold text-xl text-white m-3 p-1"> 
             {page}/5
         </StyledText>
     )


### PR DESCRIPTION
New With Changes:

<img width="383" alt="Quizzy Page Count Font Size:Style Fix" src="https://github.com/user-attachments/assets/cf2f4134-56b1-4034-8ed5-c7c93a9cfbfd">


Old Before Changes:

<img width="383" alt="Quizzy Page Count Font Size:Style Original" src="https://github.com/user-attachments/assets/f22f3711-4c6a-420e-94d9-4f9a312d871c">
