### PR TITLE
Fix Firestore Query

### DIFF
--- a/firebase/firebaseConfig.js
+++ b/firebase/firebaseConfig.js
@@ -25,17 +25,11 @@ const app = initializeApp(firebaseConfig);
 
 export async function getDailyQuiz() {
     const db = getFirestore(app);
-    const date = todayFormatted
-    const q = query(collection(db, 'dailies', `${date}`, 'questions'), where("approved", "==", true));
-    // const q = query(doc(db, 'dailies', `${date}`));
+    const date = todayFormatted;
+    const q = query(doc(db, 'dailies', `${date}`));
     const querySnapshot = await getDoc(q);
 
-    
-    const quiz = querySnapshot.data();
-    
-    
-    return quiz;
-    
+    return querySnapshot.data().quiz;    
 }
 
 

--- a/pages/LoadingPage.js
+++ b/pages/LoadingPage.js
@@ -41,8 +41,7 @@ export default function LoadingPage({navigation}){
     const load = async () => {
       
       const fbRes = await getDailyQuiz();
-      const quiz = fbRes.quiz.slice(0,5);
-      console.log(quiz);
+      const quiz = fbRes.slice(0,5);
       setQuiz(quiz);
       setTimeout(()=> {setLoaded(true)},1250);
       //setLoaded(true);


### PR DESCRIPTION
Set Firestore query to request quiz questions directly rather than through a key called 'questions' since the database contains the quiz questions as objects directly within the quiz.