### PR TITLE
Better-responsive-pages

### DIFF
--- a/global.css
+++ b/global.css
@@ -4,26 +4,22 @@
 
 @font-face {
     font-family: "KGHappy";
-    src: url("public/fonts/KGHAPPY.ttf")
-    format('truetype');
+    src: url("public/fonts/KGHAPPY.ttf") format('truetype');
 }
 
 @font-face {
     font-family: "Lexend";
-    src: url("public/fonts/Lexend-VariableFont_wght.ttf")
-    format('truetype');
+    src: url("public/fonts/Lexend-VariableFont_wght.ttf") format('truetype');
 }
 
 @font-face {
     font-family: "Jost";
-    src: url("public/fonts/Jost-VariableFont_wght.ttf")
-    format('truetype');
+    src: url("public/fonts/Jost-VariableFont_wght.ttf") format('truetype');
 }
 
 @font-face {
     font-family: "Futura-Medium";
-    src: url("public/fonts/Futura-Medium.otf")
-    format('embedded-opentype');
+    src: url("public/fonts/Futura-Medium.otf") format('embedded-opentype');
 }
 
 
@@ -44,5 +40,5 @@
     --light-green: #DEFEBF;
     --dark-green: #78C93C;
     --darker-green: #6BA530;   
-};
+}
 

--- a/pages/GamePage.js
+++ b/pages/GamePage.js
@@ -142,10 +142,10 @@ export default function GamePage ( { navigation, route }) {
   return (
     
     <StyledView className={`h-screen flex-1 flex-col bg-light-purple ${desaturated ? 'grayscale' : ''} `}>
-      <StyledView className="h-10pct">
+      <StyledView className="h-125">
 
       </StyledView>
-      <StyledView className="flex-row items-end justify-between mx-21 pb-3 h-10pct w-full">
+      <StyledView className="flex-row items-end justify-between mx-125 pb-3 h-10pct ">
       <Header 
         onTimeOut={handleTimeOut}
         score={score} 
@@ -155,11 +155,11 @@ export default function GamePage ( { navigation, route }) {
         </StyledView>
 
       <StyledView className={`flex-1 items-center justify-between bg-light-purple mx-37 rounded-lg `} >
-        <StyledView className="h1/3 justify-center w-full px-1">
+        <StyledView className="h1/3 justify-center w-full px-2">
         <QuestionDisplay currentQuestion={quiz[currentQuestion].question} /> 
         </StyledView>
 
-        <StyledView className="h-30pct pb-10 w-full justify-evenly mx-28"> 
+        <StyledView className="h-2/3 pb-10pct w-full justify-center px-125"> 
             {choices.map((choice, i) => {
               return <ChoiceDisplay
                 key= {i} // Used by React under the hood.

--- a/pages/GamePage.js
+++ b/pages/GamePage.js
@@ -145,7 +145,7 @@ export default function GamePage ( { navigation, route }) {
       <StyledView className="h-10pct">
 
       </StyledView>
-      <StyledView className="flex-row items-end justify-between px-5 pb-3 h-10pct w-full">
+      <StyledView className="flex-row items-end justify-between mx-21 pb-3 h-10pct w-full">
       <Header 
         onTimeOut={handleTimeOut}
         score={score} 
@@ -154,12 +154,12 @@ export default function GamePage ( { navigation, route }) {
         />
         </StyledView>
 
-      <StyledView className={`flex-1 items-center justify-between bg-light-purple mx-5 rounded-lg `} >
+      <StyledView className={`flex-1 items-center justify-between bg-light-purple mx-37 rounded-lg `} >
         <StyledView className="h1/3 justify-center w-full px-1">
         <QuestionDisplay currentQuestion={quiz[currentQuestion].question} /> 
         </StyledView>
 
-        <StyledView className="h-30pct pb-10 w-full justify-evenly"> 
+        <StyledView className="h-30pct pb-10 w-full justify-evenly mx-28"> 
             {choices.map((choice, i) => {
               return <ChoiceDisplay
                 key= {i} // Used by React under the hood.

--- a/pages/GamePageChildren/ChoiceDisplay.js
+++ b/pages/GamePageChildren/ChoiceDisplay.js
@@ -11,13 +11,13 @@ const StyledPressable = styled(Pressable);
 export default function ChoiceDisplay ({choice, onPressIn, onPressOut, choiceState}) {
   const getButtonStyle = () => {
     if (choiceState === "Disabled") {
-       return "min-h-10pct bg-white shadow-choiceDisplayButtonShadow m-[10px] p-[20px] flex rounded-lg ";
+       return "min-h-95px bg-white shadow-choiceDisplayButtonShadow m-[10px] p-[20px] flex rounded-lg ";
     } else if (choiceState === "Correct") {
-      return "min-h-10pct bg-dark-green shadow-correctChoiceDisplayButtonShadow m-[10px] p-[20px] flex  rounded-lg ";
+      return "min-h-95px bg-dark-green shadow-correctChoiceDisplayButtonShadow m-[10px] p-[20px] flex  rounded-lg ";
     } else if (choiceState === "Incorrect") {
-      return "min-h-10pct bg-dark-red shadow-incorrectChoiceDisplayButtonShadow  m-[10px] p-[20px] flex rounded-lg ";
+      return "min-h-95px bg-dark-red shadow-incorrectChoiceDisplayButtonShadow  m-[10px] p-[20px] flex rounded-lg ";
     } else {
-      return "min-h-10pct bg-white shadow-choiceDisplayButtonShadow m-[10px] p-[20px] flex  rounded-lg ";
+      return "min-h-95px bg-white shadow-choiceDisplayButtonShadow m-[10px] p-[20px] flex  rounded-lg ";
     }
   }
 

--- a/pages/GamePageChildren/ChoiceDisplay.js
+++ b/pages/GamePageChildren/ChoiceDisplay.js
@@ -11,25 +11,25 @@ const StyledPressable = styled(Pressable);
 export default function ChoiceDisplay ({choice, onPressIn, onPressOut, choiceState}) {
   const getButtonStyle = () => {
     if (choiceState === "Disabled") {
-       return "bg-white shadow-choiceDisplayButtonShadow m-[10px] p-[20px] flex items-center justify-center rounded-lg";
+       return "min-h-10pct bg-white shadow-choiceDisplayButtonShadow m-[10px] p-[20px] flex rounded-lg ";
     } else if (choiceState === "Correct") {
-      return "bg-dark-green shadow-correctChoiceDisplayButtonShadow m-[10px] p-[20px] flex items-center justify-center rounded-lg";
+      return "min-h-10pct bg-dark-green shadow-correctChoiceDisplayButtonShadow m-[10px] p-[20px] flex  rounded-lg ";
     } else if (choiceState === "Incorrect") {
-      return "bg-dark-red shadow-incorrectChoiceDisplayButtonShadow  m-[10px] p-[20px] flex items-center justify-center rounded-lg";
+      return "min-h-10pct bg-dark-red shadow-incorrectChoiceDisplayButtonShadow  m-[10px] p-[20px] flex rounded-lg ";
     } else {
-      return "bg-white shadow-choiceDisplayButtonShadow m-[10px] p-[20px] flex items-center justify-center rounded-lg";
+      return "min-h-10pct bg-white shadow-choiceDisplayButtonShadow m-[10px] p-[20px] flex  rounded-lg ";
     }
   }
 
   const getTextStyle = () => {
     if (choiceState === "Disabled") {
-      return "font-futura-medium text-xl text-grey-1 leading-6";
+      return "font-futura-medium text-xl text-grey-1 leading-6 text-left";
     } else if (choiceState === "Correct") {
-      return "font-futura-medium text-xl text-light-green leading-6";
+      return "font-futura-medium text-xl text-light-green leading-6 text-left";
     } else if (choiceState === "Incorrect") {
-      return "font-futura-medium text-xl text-light-red leading-6";
+      return "font-futura-medium text-xl text-light-red leading-6 text-left";
     } else {
-      return "font-futura-medium text-xl text-grey-4 leading-6";
+      return "font-futura-medium text-xl text-grey-4 leading-6 text-left";
     }
   }
   

--- a/pages/ScorePage.js
+++ b/pages/ScorePage.js
@@ -91,10 +91,10 @@ export default function ScorePage({ route, navigation }) {
                 <Text className="pb-3 text-sm font-lexend">Click on the answers to read the article.</Text>
                 {results.map((result,idx) => {
                     return (
-                        <Pressable className="w-full h-9 mb-[10px] flex flex-row justify-between items-center" 
+                        <Pressable className="w-full h-9 mb-[10px] flex flex-row justify-items-start items-center" 
                             onPress={()=> window.open(result.link)}
                         key={result.id}>
-                            <View className="h-full bg-[#E3E3E3] w-[100%] rounded-md absolute top-2 right-[-5]" />
+                            <View className=" bg-[#E3E3E3] w-[100%] rounded-md absolute top-2 right-[-5]" />
                             <View className={`${record[idx] === 'correct' ?
                                 "h-full bg-[#6BA530] w-full rounded-md absolute top-1" :
                                 "h-full bg-darker-red w-full rounded-md absolute top-1"}`} />
@@ -103,15 +103,15 @@ export default function ScorePage({ route, navigation }) {
                              "h-full bg-[#78C93C] w-full rounded-md absolute" :
                              "h-full bg-dark-red w-full rounded-md absolute"}`} />
                             {/* <View className="h-full bg-[#78C93C] w-full rounded-md absolute" /> */}
-                            <Text className="pl-2 text-sm font-lexend font-bold text-white">{result.id}</Text>
-                            <Text className="text-lg font-lexend font-bold text-white underline grow-4 text-center">{result.answer}</Text>
-                            <View className="pr-1">
+                            <Text className="px-125 text-lg font-lexend font-bold text-white">{result.id}</Text>
+                            <Text className="text-lg font-lexend font-bold text-white no-underline grow-4 text-left mr-auto">{result.answer}</Text>
+                            <View className="pr-1 justify-self-end">
                                 <Ionicons name="exit-outline" size={24} color="white" />
                             </View>
                         </Pressable>
                     )
                 })}
-                <Text className="pt-2 text-lg font-lexend">
+                <Text className="pt-01 text-lg font-lexend">
                     Next news quiz in <Text className="font-bold">12:19:00</Text>
                 </Text>
             </View>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,7 +9,22 @@ module.exports = {
   content: ["./App.{js,jsx,ts,tsx}", "./pages/**/*.{js,jsx,ts,tsx}", "./modals/**/*.{js,jsx,ts,tsx}"],
   theme: {
     extend: {
+      screens: {
+        'sm' : '360px',
+        'md' : '834px',
+        'lg' : '1512px',
+      },
+      spacing: {
+        '01' : '.01rem',
+        '2' : '2rem',
+        '21' : '0.05vw',
+        '37' : '0.10vw',
+        '28' : '0.07vw',
+        '125' : '1.25rem',
+        '10pct' : '10%',
+      },
       height: {
+        '9pct': '9%',
         '10pct': '10%',
         'timer-height': '60px !important',
       },


### PR DESCRIPTION
Implemented utility classes to improve performance and presentation on smaller screens, as well as made adjustments to spacings to better align with figma mockups.

Will need further improvement to get them closer to Figma Designs, but this will atleast allow for better testing/viewing on mobile devices. Before if the app rendered beyond the constraints of the viewport height, there would be inaccessible overflow. Now everything should atleast be visible without the need to scroll or without any cut-off.

Larger screens will need further development.

Also naming for spacing aliases in tailwind.config could be improved, e.g. made more intuitive.